### PR TITLE
Shell environment for nix

### DIFF
--- a/code/shell.nix
+++ b/code/shell.nix
@@ -1,0 +1,18 @@
+let
+  pkgs = import (fetchTarball("https://github.com/NixOS/nixpkgs/archive/acc86a93168e272538f4ce459eaef3f58848ebd0.tar.gz")) {};
+in pkgs.mkShell {
+  buildInputs = [
+    (pkgs.rWrapper.override { packages = with pkgs.rPackages; [
+      ggplot2
+      dplyr
+      xts
+      tidyverse
+      ggpubr
+      pracma
+      shiny
+      plotly
+      leaflet
+      rsconnect
+    ]; })
+ ];
+}

--- a/code/shell.nix
+++ b/code/shell.nix
@@ -3,8 +3,6 @@ let
 in pkgs.mkShell {
   buildInputs = [
     (pkgs.rWrapper.override { packages = with pkgs.rPackages; [
-      ggplot2
-      dplyr
       xts
       tidyverse
       ggpubr


### PR DESCRIPTION
If you have `nix` package manager, instead of having to install IDEs and packages manually, simply run this command
```
nix-shell shell.nix --command "Rscript CoRisk-Index-Code/app.R"
```
in directory `code`.